### PR TITLE
Change to node-sql-2 name in definition and in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _sql string builder for node_ - supports PostgreSQL, mysql, Microsoft SQL Server
 ## install
 
 ```sh
-$ npm install sql
+$ npm install node-sql-2
 ```
 
 ## use

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -4,7 +4,7 @@
  * Whole project is MIT licensed, so, we can use it. We also feed back any
  * improvements, questions, concerns.
  */
-declare module "sql" {
+declare module "node-sql-2" {
 
 	type SQLDialects =
 		| "mssql"


### PR DESCRIPTION
Without proposed changes can't use node-sql-2 from npm.
Typescrypt v.3.5.2 
- complains "Cannot find module 'sql'. ts(2307)" when the old import is `import * as sql from 'sql';`
- complains "File '.../node_modules/node-sql-2/lib/types.d.ts' is not a module. ts(2306)" when import is updated to `import * as sql from 'node-sql-2';`.