### PR TITLE
Add operators '?|' and '?&'

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -600,16 +600,7 @@ Postgres.prototype.visitContainedBy = function(containedBy) {
   text += ' <@ ' + this.visit(containedBy.set);
   return [text];
 };
-Postgres.prototype.visitExistsKeyElement=function (exists){
-  var text = this.visit(exists.value);
-  text+=' ?| ' + this.visit(exists.set);
-  return [text];
-};
-Postgres.prototype.visitExistsAllKeyElement=function (exists){
-  var text=this.visit(exists.value);
-  text+=' ?& ' + this.visit(exists.set);
-  return [text];
-};
+
 Postgres.prototype.visitOverlap = function(overlap) {
   var text = this.visit(overlap.value);
   text += ' && ' + this.visit(overlap.set);

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -600,7 +600,16 @@ Postgres.prototype.visitContainedBy = function(containedBy) {
   text += ' <@ ' + this.visit(containedBy.set);
   return [text];
 };
-
+Postgres.prototype.visitExistsKeyElement=function (exists){
+  var text = this.visit(exists.value);
+  text+=' ?| ' + this.visit(exists.set);
+  return [text];
+};
+Postgres.prototype.visitExistsAllKeyElement=function (exists){
+  var text=this.visit(exists.value);
+  text+=' ?& ' + this.visit(exists.set);
+  return [text];
+};
 Postgres.prototype.visitOverlap = function(overlap) {
   var text = this.visit(overlap.value);
   text += ' && ' + this.visit(overlap.set);

--- a/lib/node/valueExpression.js
+++ b/lib/node/valueExpression.js
@@ -153,7 +153,9 @@ var ValueExpressionMixin = function() {
     slice      : sliceMethod,
     cast       : castMethod,
     descending : orderMethod('DESC'),
-    case       : caseMethod
+    case       : caseMethod,
+    existsKeyElement  :binaryMethod('?|'),
+    existsAllKeyElements     :binaryMethod('?&')
   };
 };
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -178,6 +178,8 @@ declare module "node-sql-2" {
 		functions: {
 				LOWER<Name>(c:Column<Name, string>):Column<Name, string>
 		}
+		array(arr:T[]):BinaryNode
+		
 	}
 
 	interface BinaryNode {
@@ -213,6 +215,8 @@ declare module "node-sql-2" {
 		descending:OrderByValueNode
 		asc:OrderByValueNode
 		desc:OrderByValueNode
+		existsKeyElement(str:string):BinaryNode
+		existsAllKeyElements(str:string):BinaryNode
 	}
 
 	function define<Name extends string, T>(map:TableDefinition<Name, T>): Table<Name, T>;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -215,8 +215,8 @@ declare module "node-sql-2" {
 		descending:OrderByValueNode
 		asc:OrderByValueNode
 		desc:OrderByValueNode
-		existsKeyElement(str:string):BinaryNode
-		existsAllKeyElements(str:string):BinaryNode
+		existsKeyElement(node:BinaryNode):BinaryNode
+		existsAllKeyElements(node:BinaryNode):BinaryNode
 	}
 
 	function define<Name extends string, T>(map:TableDefinition<Name, T>): Table<Name, T>;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "brianc <brian.m.carlson@gmail.com>",
   "name": "node-sql-2",
   "description": "sql builder",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "homepage": "https://github.com/TokyoFarmer/node-sql-2",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "lib/",
   "types": "lib/types.d.ts",
   "scripts": {
-    "test": "node_modules/.bin/mocha",
+    "test": "mocha",
     "lint": "jshint lib test",
     "posttest": "jshint lib test"
   },
@@ -25,6 +25,10 @@
   },
   "devDependencies": {
     "jshint": "*",
-    "mocha": "*"
+    "mocha": ">6.0.0"
+  },
+  "mocha": {
+    "reporter": "dot",
+    "ui": "tdd"
   }
 }

--- a/test/column-tests.js
+++ b/test/column-tests.js
@@ -3,64 +3,64 @@
 var assert = require('assert');
 var sql = require(__dirname + '/../lib');
 
-describe('column', function() {
+suite('column', function() {
   var table = sql.define({
     name: 'user',
     columns: ['id', 'created', 'alias']
   });
 
-  it('can be accessed by property and array', function() {
+  test('can be accessed by property and array', function() {
     assert.equal(table.created, table.columns[1], 'should be able to access created both by array and property');
   });
 
-  describe('toQuery()', function() {
-    it('works', function() {
+  suite('toQuery()', function() {
+    test('works', function() {
       assert.equal(table.id.toQuery().text, '"user"."id"');
     });
 
-    it('works with a column name of "alias"', function() {
+    test('works with a column name of "alias"', function() {
       assert.equal(table.alias.toQuery().text, '"user"."alias"');
     });
 
-    it('respects AS rename', function() {
+    test('respects AS rename', function() {
       assert.equal(table.id.as('userId').toQuery().text, '"user"."id" AS "userId"');
     });
 
-    it('respects count and distinct', function() {
+    test('respects count and distinct', function() {
       assert.equal(table.id.count().distinct().as("userIdCount").toQuery().text, 'COUNT(DISTINCT("user"."id")) AS "userIdCount"');
     });
 
-    describe('in subquery with min', function() {
+    suite('in subquery with min', function() {
       var subquery = table.subQuery('subTable').select(table.id.min().as('subId'));
       var col = subquery.subId.toQuery().text;
       assert.equal(col, '"subTable"."subId"');
     });
 
-    describe('property', function() {
+    suite('property', function() {
       var table = sql.define({
         name: 'roundtrip',
         columns: {
           column_name: { property: 'propertyName' }
         }
       });
-      it('used as alias when !== column name', function() {
+      test('used as alias when !== column name', function() {
         assert.equal(table.propertyName.toQuery().text, '"roundtrip"."column_name" AS "propertyName"');
       });
-      it('uses explicit alias when !== column name', function() {
+      test('uses explicit alias when !== column name', function() {
         assert.equal(table.propertyName.as('alias').toQuery().text, '"roundtrip"."column_name" AS "alias"');
       });
-      it('maps to column name in insert', function() {
+      test('maps to column name in insert', function() {
         assert.equal(table.insert({propertyName:'propVal'}).toQuery().text, 'INSERT INTO "roundtrip" ("column_name") VALUES ($1)');
       });
-      it('maps to column name in update', function() {
+      test('maps to column name in update', function() {
         assert.equal(table.update({propertyName:'propVal'}).toQuery().text, 'UPDATE "roundtrip" SET "column_name" = $1');
       });
-      it('explicitly selected by *', function() {
+      test('explicitly selected by *', function() {
         assert.equal(table.select(table.star()).from(table).toQuery().text, 'SELECT "roundtrip"."column_name" AS "propertyName" FROM "roundtrip"');
       });
     });
 
-    describe('autoGenerate', function() {
+    suite('autoGenerate', function() {
       var table = sql.define({
         name: 'ag',
         columns: {
@@ -68,42 +68,42 @@ describe('column', function() {
           name: {}
         }
       });
-      it('does not include auto generated columns in insert', function() {
+      test('does not include auto generated columns in insert', function() {
         assert.equal(table.insert({id:0, name:'name'}).toQuery().text,'INSERT INTO "ag" ("name") VALUES ($1)');
       });
-      it('does not include auto generated columns in update', function() {
+      test('does not include auto generated columns in update', function() {
         assert.equal(table.update({id:0, name:'name'}).toQuery().text,'UPDATE "ag" SET "name" = $1');
       });
     });
 
-    describe('white listed', function() {
+    suite('white listed', function() {
       var table = sql.define({
         name: 'wl',
         columnWhiteList: true,
         columns: ['id', 'name']
       });
-      it('excludes insert properties that are not a column', function() {
+      test('excludes insert properties that are not a column', function() {
         assert.equal(table.insert({id:0, _private:'_private', name:'name'}).toQuery().text, 'INSERT INTO "wl" ("id", "name") VALUES ($1, $2)');
       });
-      it('excludes update properties that are not a column', function() {
+      test('excludes update properties that are not a column', function() {
         assert.equal(table.update({id:0, _private:'_private', name:'name'}).toQuery().text, 'UPDATE "wl" SET "id" = $1, "name" = $2');
       });
     });
 
-    describe('not white listed', function() {
+    suite('not white listed', function() {
       var table = sql.define({
         name: 'wl',
         columns: ['id', 'name']
       });
-      it('throws for insert properties that are not a column', function() {
+      test('throws for insert properties that are not a column', function() {
         assert.throws(function() { table.insert({id:0, _private:'_private', name:'name'}); }, Error);
       });
-      it('throws for update properties that are not a column', function() {
+      test('throws for update properties that are not a column', function() {
         assert.throws(function() { table.update({id:0, _private:'_private', name:'name'}); }, Error);
       });
     });
 
-    describe('snake to camel', function() {
+    suite('snake to camel', function() {
       var table = sql.define({
         name: 'sc',
         snakeToCamel: true,
@@ -112,17 +112,17 @@ describe('column', function() {
           not_to_camel: {property: 'not2Cam'}
         }
       });
-      it('for snake column names with no explicit property name', function(){
+      test('for snake column names with no explicit property name', function(){
         assert.equal(table.makeMeCamel.toQuery().text, '"sc"."make_me_camel" AS "makeMeCamel"');
       });
-      it('but not when with explicit property name', function() {
+      test('but not when with explicit property name', function() {
         assert.equal(table.not2Cam.toQuery().text, '"sc"."not_to_camel" AS "not2Cam"');
       });
-      it('does not use property alias within CASE ... END', function() {
+      test('does not use property alias within CASE ... END', function() {
         assert.equal(table.makeMeCamel.case([table.makeMeCamel.equals(0)],[table.makeMeCamel]).as('rename').toQuery().text,
           '(CASE WHEN ("sc"."make_me_camel" = $1) THEN "sc"."make_me_camel" END) AS "rename"');
       });
-      it('respects AS rename in RETURNING clause', function() {
+      test('respects AS rename in RETURNING clause', function() {
         assert.equal(table.update({makeMeCamel:0}).returning(table.makeMeCamel.as('rename')).toQuery().text,
           'UPDATE "sc" SET "make_me_camel" = $1 RETURNING "make_me_camel" AS "rename"');
       });

--- a/test/dialects/array-tests.js
+++ b/test/dialects/array-tests.js
@@ -95,7 +95,7 @@ Harness.test({
   params: [1,2,3,2]
 });
 
-Harness.it({
+Harness.test({
   query: post.select(
     post.tags.existsKeyElement(Sql.array('nodejs', 'js', 'node'))
   ),
@@ -106,7 +106,7 @@ Harness.it({
   params: ['nodejs', 'js', 'node']
 });
 
-Harness.it({
+Harness.test({
   query: post.select(
     post.tags.existsAllKeyElements(Sql.array('nodejs', 'js'))
   ),

--- a/test/dialects/array-tests.js
+++ b/test/dialects/array-tests.js
@@ -94,3 +94,25 @@ Harness.test({
   },
   params: [1,2,3,2]
 });
+
+Harness.it({
+  query: post.select(
+    post.tags.existsKeyElement(Sql.array('nodejs', 'js', 'node'))
+  ),
+  pg: {
+    text  : 'SELECT ("post"."tags" ?| ARRAY[$1, $2, $3]) FROM "post"',
+    string: 'SELECT ("post"."tags" ?| ARRAY[\'nodejs\', \'js\', \'node\']) FROM "post"'
+  },
+  params: ['nodejs', 'js', 'node']
+});
+
+Harness.it({
+  query: post.select(
+    post.tags.existsAllKeyElements(Sql.array('nodejs', 'js'))
+  ),
+  pg: {
+    text  : 'SELECT ("post"."tags" ?& ARRAY[$1, $2]) FROM "post"',
+    string: 'SELECT ("post"."tags" ?& ARRAY[\'nodejs\', \'js\']) FROM "post"'
+  },
+  params: ['nodejs', 'js']
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---reporter dot
---ui tdd


### PR DESCRIPTION
Added the following two jsonb operators 
 - ?| :: text[] - Do any of these array strings exist as top-level keys? 
    > ex. '{"a":1, "b":2, "c":3}'::jsonb ?\| array['b', 'c']
 - ?& :: text[] -  Do all of these array strings exist as top-level keys?
    > ex. '["a", "b"]'::jsonb ?& array['a', 'b']

